### PR TITLE
Fix Example for Adding Nodes Using Static Tokens

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -392,7 +392,7 @@ flag to "xxxxxx". This node will join the cluster as a regular node but also
 as a proxy server:
 
 ```bash
-teleport start --roles=node,auth --token=xxxxx --auth-server=10.0.10.5
+teleport start --roles=node,proxy --token=xxxxx --auth-server=10.0.10.5
 ```
 
 ### Short-lived Tokens


### PR DESCRIPTION
Given the sentence right before the example, the roles to start should be `node` and `proxy`, not `node` and `auth`.